### PR TITLE
set up GPU cluster

### DIFF
--- a/cluster-policy.yaml
+++ b/cluster-policy.yaml
@@ -1,0 +1,4 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy

--- a/cp-setup.sh
+++ b/cp-setup.sh
@@ -1,0 +1,29 @@
+oc apply -f cluster-policy.yaml
+oc wait --for=jsonpath='{.status.state}'=ready clusterpolicy/gpu-cluster-policy --timeout=600s
+
+oc get pods,daemonset -n nvidia-gpu-operator
+
+oc project nvidia-gpu-operator
+
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: cuda-container
+      image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # requesting 1 GPU
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+EOF
+
+oc wait --for=jsonpath='{.status.phase}'=Succeeded pod/gpu-pod --timeout=120s
+
+oc logs gpu-pod

--- a/inferenceservice.yaml
+++ b/inferenceservice.yaml
@@ -1,0 +1,43 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    openshift.io/display-name: granite-3.1-8b-lab-v1-1.4.0 - v1
+    serving.knative.openshift.io/enablePassthrough: "true"
+    serving.kserve.io/deploymentMode: Serverless
+    sidecar.istio.io/inject: "true"
+    sidecar.istio.io/rewriteAppHTTPProbers: "true"
+  labels:
+    modelregistry.opendatahub.io/inference-service-id: "4"
+    modelregistry.opendatahub.io/model-version-id: "2"
+    modelregistry.opendatahub.io/name: modelregistry-public
+    modelregistry.opendatahub.io/registered-model-id: "1"
+    opendatahub.io/dashboard: "true"
+  name: granite-31-8b-lab-v1-140-v1
+spec:
+  predictor:
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      args:
+        - --max-model-len=16384
+        - --model
+        - /mnt/models
+      modelFormat:
+        name: vLLM
+      name: ""
+      resources:
+        limits:
+          cpu: "4"
+          memory: 16Gi
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "1"
+          memory: 256Mi
+          nvidia.com/gpu: "1"
+      runtime: granite-31-8b-lab-v1-140-v1
+      storageUri: oci://registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-lab-v1:1.4.0
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists

--- a/kmm-subscription.yaml
+++ b/kmm-subscription.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kmm
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-kmm-
+  namespace: openshift-kmm
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kernel-module-management
+  namespace: openshift-kmm
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kernel-module-management
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: kernel-module-management.v2.3.0

--- a/kustomize-gpu/job.yaml
+++ b/kustomize-gpu/job.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: odh-kubeflow-model-registry-setup
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: odh-kubeflow-model-registry-setup
+  namespace: odh-kubeflow-model-registry-setup
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: odh-kubeflow-model-registry-setup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: odh-kubeflow-model-registry-setup
+    namespace: odh-kubeflow-model-registry-setup
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: odh-kubeflow-model-registry-setup
+  namespace: odh-gpu-setup
+spec:
+  template:
+    spec:
+      containers:
+        - name: installer
+          command:
+            - /bin/bash
+            - -c
+            - |
+              #!/usr/bin/env bash
+              set -o nounset
+              set -o pipefail
+
+
+              cd /tmp || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/cluster-policy.yaml || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/cp-setup.sh || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/kmm-subscription.yaml || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/nfd.yaml || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/nfd-setup.sh || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/nodefeature-subcription.yaml || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/nvidia-gpu-subscription.yaml || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/subscriptions-gpu.sh || exit
+              
+              wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+              mv jq-linux-amd64 jq
+              chmod +x jq
+              export PATH=/tmp:$PATH
+
+              chmod +x subscriptions-gpu.sh
+              chmod +x cp-setup.sh
+              chmod +x nfd-setup.sh
+          
+              ./subscriptions-gpu.sh || exit
+              ./nfd-setup.sh || exit
+              ./cp-setup.sh || exit
+
+          image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.16
+
+      restartPolicy: OnFailure
+      serviceAccountName: odh-kubeflow-model-registry-setup

--- a/kustomize-gpu/kustomization.yaml
+++ b/kustomize-gpu/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - job.yaml

--- a/nfd-setup.sh
+++ b/nfd-setup.sh
@@ -1,0 +1,8 @@
+oc apply -f nfd.yaml
+oc wait --for=condition=available nodefeaturediscovery/nfd-instance --timeout=300s
+
+sleep 15
+
+oc get nodes -o yaml | grep feature.node.kubernetes.io/pci-10de.present
+
+exit $?

--- a/nfd.yaml
+++ b/nfd.yaml
@@ -1,0 +1,5 @@
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd

--- a/nodefeature-subscription.yaml
+++ b/nodefeature-subscription.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nfd
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-nfd-
+  namespace: openshift-nfd
+spec:
+  targetNamespaces:
+    - openshift-nfd
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: nfd.4.16.0-202502250034

--- a/nvidia-gpu-subscription.yaml
+++ b/nvidia-gpu-subscription.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-gpu-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: nvidia-gpu-operator-
+  namespace: nvidia-gpu-operator
+spec:
+  targetNamespaces:
+    - nvidia-gpu-operator
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  namespace: nvidia-gpu-operator
+spec:
+  channel: v25.3
+  installPlanApproval: Automatic
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: gpu-operator-certified.v25.3.0

--- a/servingruntime.yaml
+++ b/servingruntime.yaml
@@ -1,0 +1,45 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  annotations:
+    opendatahub.io/accelerator-name: migrated-gpu
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/hardware-profile-name: migrated-gpu-mglzi-serving
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    opendatahub.io/template-display-name: vLLM ServingRuntime for KServe
+    opendatahub.io/template-name: vllm-runtime
+    openshift.io/display-name: granite-31-8b-lab-v1-140-v1
+  name: granite-31-8b-lab-v1-140-v1
+spec:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8080"
+  containers:
+    - args:
+        - --port=8080
+        - --model=/mnt/models
+        - --served-model-name={{.Name}}
+      command:
+        - python
+        - -m
+        - vllm.entrypoints.openai.api_server
+      env:
+        - name: HF_HOME
+          value: /tmp/hf_home
+      image: quay.io/opendatahub/vllm:fast
+      name: kserve-container
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: vLLM
+  volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 2Gi
+      name: shm

--- a/smm.yaml
+++ b/smm.yaml
@@ -1,0 +1,8 @@
+apiVersion: maistra.io/v1
+kind: ServiceMeshMember
+metadata:
+  name: default
+spec:
+  controlPlaneRef:
+    name: data-science-smcp
+    namespace: istio-system

--- a/subscriptions-gpu.sh
+++ b/subscriptions-gpu.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+oc apply -f ./nodefeature-subcription.yaml
+while true; do
+	oc get csv -o name -n openshift-nfd | grep nfd > nfd.txt
+	if [ -s nfd.txt ]; then
+		export NFD=$(cat nfd.txt)
+		echo "nfd csv is ${NFD}}"
+		break
+	else
+		echo "nfd.txt still emtpy"
+		sleep 5
+	fi
+done
+oc wait --for=jsonpath='{.status.phase}'=Succeeded "$NFD" -n openshift-nfd --timeout=600s
+
+oc apply -f ./kmm-subscription.yaml
+while true; do
+	oc get csv -o name -n openshift-kmm | grep kernel > kmm.txt
+	if [ -s kmm.txt ]; then
+		export KMM=$(cat kmm.txt)
+		echo "kmm csv is ${KMM}"
+		break
+	else
+		echo "kmm.txt still emtpy"
+		sleep 5
+	fi
+done
+oc wait --for=jsonpath='{.status.phase}'=Succeeded "KMM" -n openshift-kmm --timeout=300s
+
+
+oc apply -f ./nvidia-gpu-subscription.yaml
+while true; do
+	oc get csv -o name -n nvidia-gpu-operator | grep gpu > gpu.txt
+	if [ -s gpu.txt ]; then
+		export GPU=$(cat gpu.txt)
+		echo "gpu csv is ${GPU}"
+		break
+	else
+		echo "gpu.txt still empty"
+		sleep 5
+	fi
+done
+oc wait --for=jsonpath='{.status.phase}'=Succeeded "$GPU" -n nvidia-gpu-operator --timeout=300s
+
+while true; do
+  oc get installplan -n nvidia-gpu-operator -o name > ip.txt
+  if [ -s ip.txt ]; then
+    export IP=$(cat ip.txt)
+    echo "ip.txt is ${IP})"
+    break
+  else
+    else "ip.txt still empty"
+    sleep 5
+  fi
+done
+oc wait --for=jsonpath='{.status.phase}'=Complete "$IP" -n nvidia-gpu-operator
+
+


### PR DESCRIPTION
my capturing of the stuff I installed, the staging / verification to go from one step to the next, in getting a GPU cluster to successfully deploy the granite-3.1-lab model from the RHOAI model catalog and coupled with https://github.com/gabemontero-appstudio-test-org/catalog-info-yaml/blob/master/catalog-info.yaml that I built with the `bac` CLI, use that model when deploying apps from a ai-rhdh-installer provisioned RHDH

I'll retry again tomorrow (had some non related quay.io issue) to validate the end to end scenario, then merge this

also includes the inferenceservice and servingruntime yaml that model registry created in my test namespace to provision the model ... in theory, could be used as a gitops based means of deploying the mode.

@johnmcollier @thepetk FYI