### PR TITLE
RHDHPAI-842: add second model registry and associated DB

### DIFF
--- a/mysql-db.yaml
+++ b/mysql-db.yaml
@@ -5,6 +5,11 @@ metadata:
   name: test-database
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-database-2
+---
+apiVersion: v1
 items:
 - apiVersion: v1
   kind: Service
@@ -148,6 +153,152 @@ items:
       template.openshift.io/expose-username: '{.data[''database-user'']}'
     name: model-registry-db
     namespace: test-database
+  stringData:
+    database-name: "model_registry"
+    database-password: "TheBlurstOfTimes" # notsecret
+    database-user: "mlmduser" # notsecret
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
+    annotations:
+      template.openshift.io/expose-uri: mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\mysql\)].port}
+    name: model-registry-db
+    namespace: test-database-2
+  spec:
+    ports:
+      - name: mysql
+        nodePort: 0
+        port: 3306
+        protocol: TCP
+        appProtocol: tcp
+        targetPort: 3306
+    selector:
+      name: model-registry-db
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
+    name: model-registry-db
+    namespace: test-database-2
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: model-registry-db
+    namespace: test-database-2
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 0
+    selector:
+      matchLabels:
+        name: model-registry-db
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: model-registry-db
+          sidecar.istio.io/inject: "false"
+      spec:
+        containers:
+          - env:
+              - name: MYSQL_USER
+                valueFrom:
+                  secretKeyRef:
+                    key: database-user
+                    name: model-registry-db
+              - name: MYSQL_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: database-password
+                    name: model-registry-db
+              - name: MYSQL_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: database-password
+                    name: model-registry-db
+              - name: MYSQL_DATABASE
+                valueFrom:
+                  secretKeyRef:
+                    key: database-name
+                    name: model-registry-db
+            args:
+              - --datadir
+              - /var/lib/mysql/datadir
+              - --default-authentication-plugin=mysql_native_password
+            image: mysql:8.3.0
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - mysqladmin -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} ping
+              initialDelaySeconds: 15
+              periodSeconds: 10
+              timeoutSeconds: 5
+            name: mysql
+            ports:
+              - containerPort: 3306
+                protocol: TCP
+            readinessProbe:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - mysql -D ${MYSQL_DATABASE} -u${MYSQL_USER} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'
+              initialDelaySeconds: 10
+              timeoutSeconds: 5
+            securityContext:
+              capabilities: {}
+              privileged: false
+            terminationMessagePath: /dev/termination-log
+            volumeMounts:
+              - mountPath: /var/lib/mysql
+                name: model-registry-db-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+          - name: model-registry-db-data
+            persistentVolumeClaim:
+              claimName: model-registry-db
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+    name: model-registry-db
+    namespace: test-database-2
   stringData:
     database-name: "model_registry"
     database-password: "TheBlurstOfTimes" # notsecret

--- a/registry-rhoai.yaml
+++ b/registry-rhoai.yaml
@@ -40,6 +40,47 @@ items:
           name: model-registry-db
         port: 3306
         skipDBCreation: false
-        username: mlmduser       
+        username: mlmduser
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app.kubernetes.io/name: model-registry-db-2
+        app.kubernetes.io/instance: model-registry-db-2
+        app.kubernetes.io/part-of: model-registry-db-2
+        app.kubernetes.io/managed-by: kustomize
+      annotations:
+        template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+        template.openshift.io/expose-password: '{.data[''database-password'']}'
+        template.openshift.io/expose-username: '{.data[''database-user'']}'
+      name: model-registry-db-2
+    stringData:
+      database-name: model_registry
+      database-password: TheBlurstOfTimes
+      database-user: mlmduser
+  - apiVersion: modelregistry.opendatahub.io/v1alpha1
+    kind: ModelRegistry
+    metadata:
+      name: modelregistry-public-2
+      namespace: rhoai-model-registries
+    spec:
+      grpc: {}
+      rest: {}
+      istio:
+        authProvider: redhat-ods-applications-auth-provider
+        gateway:
+          grpc:
+            tls: {}
+          rest:
+            tls: {}
+      mysql:
+        host: model-registry-db.test-database-2.svc.cluster.local
+        database: model_registry
+        passwordSecret:
+          key: database-password
+          name: model-registry-db
+        port: 3306
+        skipDBCreation: false
+        username: mlmduser
 kind: List
 metadata: {}


### PR DESCRIPTION
did not bother with validating deployment like with first one ... you have the explicitly configure the MR_ROUTE env var on the bridge to have a second registry in order for it to be accessed