### PR TITLE
adjust model catalog dashboard sync with model catalog REST service for late Aug/early Sept changes

### DIFF
--- a/kustomize/job.yaml
+++ b/kustomize/job.yaml
@@ -56,6 +56,8 @@ spec:
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/subscriptions.sh || exit
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/dsc-setup.sh || exit
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/model-registry-setup.sh || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/default-model-catalog-cm.yaml || exit
+              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/model-catalog-sources-cm.yaml || exit
               
               wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/kustomization.yaml || exit
               wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-configmap.yaml || exit
@@ -67,15 +69,6 @@ spec:
               mv model-catalog-configmap.yaml rhoai-model-catalog-dashboard
               mv model-catalog-rbac.yaml rhoai-model-catalog-dashboard
               mv model-catalog-unmanaged-sources.yaml rhoai-model-catalog-dashboard
-
-              wget https://raw.githubusercontent.com/gabemontero/model-registry/refs/heads/temp-model-catalog-populate-configmap-only/manifests/kustomize/options/catalog/kustomization.yaml || exit
-              wget https://raw.githubusercontent.com/gabemontero/model-registry/refs/heads/temp-model-catalog-populate-configmap-only/manifests/kustomize/options/catalog/sources.yaml || exit
-              wget https://raw.githubusercontent.com/gabemontero/model-registry/refs/heads/temp-model-catalog-populate-configmap-only/manifests/kustomize/options/catalog/sample-catalog.yaml || exit
-
-              mkdir rhoai-model-catalog-rest
-              mv kustomization.yaml rhoai-model-catalog-rest
-              mv sources.yaml rhoai-model-catalog-rest
-              mv sample-catalog.yaml rhoai-model-catalog-rest
               
               wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
               mv jq-linux-amd64 jq

--- a/model-registry-setup.sh
+++ b/model-registry-setup.sh
@@ -8,7 +8,6 @@ oc wait --for=condition=available deployment/model-registry-db --timeout=5m
 oc apply -f odh-model-registrires-ns.yaml
 
 oc project odh-model-registries
-oc apply -k ./rhoai-model-catalog-rest -n odh-model-registries
 oc apply -f registry.yaml
 oc wait --for=condition=available modelregistry.modelregistry.opendatahub.io/modelregistry-public --timeout=5m
 
@@ -16,5 +15,11 @@ oc apply -f odh-admins.yaml
 
 # should not be needed long term by model registry / odh-model-controller
 oc set env  deployment/odh-model-controller -n opendatahub MR_SKIP_TLS_VERIFY=true
-oc wait --for=jsonpath='{.status.observedGeneration}'=2 deployment/odh-model-controller -n opendatahub --timeout=300s
+sleep 60
+#oc wait --for=jsonpath='{.status.observedGeneration}'=2 deployment/odh-model-controller -n opendatahub --timeout=300s
+
+oc apply -f default-model-catalog-cm.yaml
+oc apply -f model-catalog-sources-cm.yaml
+
+oc get pods -o name | grep catalog | xargs -l -r oc delete 
 


### PR DESCRIPTION
with this, for both ODH 2.33 and 2.34 should again work for accesses like 

`curl -k -H "Authorization: Bearer $TOKEN" $URL2/api/model_catalog/v1alpha1/sources/Red%20Hat/models/rhelai1/granite-8b-code-base` 

where URL2 is the route address of the model catalog in the `odh-model-registries` NS