### PR TITLE
odh 235

### DIFF
--- a/kustomize-rhoai/job.yaml
+++ b/kustomize-rhoai/job.yaml
@@ -57,10 +57,10 @@ spec:
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/default-dsci-rhoai.yaml || exit
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/model-registry-setup-rhoai.sh || exit
               
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/kustomization.yaml || exit
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-configmap.yaml || exit
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-rbac.yaml || exit
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-unmanaged-sources.yaml || exit 
+              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.37.0/manifests/rhoai/shared/apps/model-catalog/kustomization.yaml || exit
+              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.37.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-configmap.yaml || exit
+              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.37.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-rbac.yaml || exit
+              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.37.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-unmanaged-sources.yaml || exit 
               
               mkdir rhoai-model-catalog
               mv kustomization.yaml rhoai-model-catalog

--- a/kustomize/job.yaml
+++ b/kustomize/job.yaml
@@ -56,22 +56,6 @@ spec:
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/subscriptions.sh || exit
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/dsc-setup.sh || exit
               wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/model-registry-setup.sh || exit
-              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/default-model-catalog-cm.yaml || exit
-              wget https://raw.githubusercontent.com/redhat-ai-dev/odh-kubeflow-model-registry-setup/refs/heads/main/model-catalog-sources-cm.yaml || exit
-              
-              wget https://raw.githubusercontent.com/kubeflow/model-registry/refs/heads/main/catalog/internal/catalog/testdata/test-yaml-catalog.yaml || exit
-              wget https://raw.githubusercontent.com/opendatahub-io/model-metadata-collection/refs/heads/main/data/models-catalog.yaml || exit
-              
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/kustomization.yaml || exit
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-configmap.yaml || exit
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-rbac.yaml || exit
-              wget https://raw.githubusercontent.com/opendatahub-io/odh-dashboard/refs/tags/v2.34.0/manifests/rhoai/shared/apps/model-catalog/model-catalog-unmanaged-sources.yaml || exit 
-              
-              mkdir rhoai-model-catalog-dashboard
-              mv kustomization.yaml rhoai-model-catalog-dashboard
-              mv model-catalog-configmap.yaml rhoai-model-catalog-dashboard
-              mv model-catalog-rbac.yaml rhoai-model-catalog-dashboard
-              mv model-catalog-unmanaged-sources.yaml rhoai-model-catalog-dashboard
               
               wget https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
               mv jq-linux-amd64 jq
@@ -88,7 +72,6 @@ spec:
               
               oc project opendatahub
               oc patch odhdashboardconfig.opendatahub.io odh-dashboard-config -n opendatahub --type merge -p '{"spec": {"dashboardConfig": {"disableModelCatalog": false}}}'
-              oc apply -k ./rhoai-model-catalog-dashboard
 
           image: registry.redhat.io/openshift4/ose-cli-rhel9:v4.16
 

--- a/model-registry-setup.sh
+++ b/model-registry-setup.sh
@@ -5,7 +5,7 @@ oc wait --for=condition=available deployment/model-registry-db --timeout=5m
 
 # https://issues.redhat.com/browse/RHOAIENG-21954 and https://github.com/opendatahub-io/model-registry-operator/pull/216 should
 # eliminate the need for this; will work with RHOAI team to see when a ODH or RHOAI operator has this change
-oc apply -f odh-model-registrires-ns.yaml
+#oc apply -f odh-model-registrires-ns.yaml
 
 oc project odh-model-registries
 oc apply -f registry.yaml
@@ -19,16 +19,14 @@ sleep 60
 
 oc get pods -n opendatahub
 
-# oc apply -f default-model-catalog-cm.yaml
+# ODH 2.35 work around for dashboard mismatch
+oc scale --replicas=0 deployment/opendatahub-operator-controller-manager -n openshift-operators
+sleep 45
 
-oc scale --replicas=0 deployment/model-registry-operator-controller-manager -n opendatahub
-sleep 45
-oc delete cm default-model-catalog -n odh-model-registries
-oc create configmap default-model-catalog --from-file=default-catalog.yaml=./test-yaml-catalog.yaml -n odh-model-registries
-oc apply -f model-catalog-sources-cm.yaml
-oc get pods -o name -n odh-model-registries | grep catalog | xargs -l -r oc delete -n odh-model-registries
-oc scale --replicas=1 deployment/model-registry-operator-controller-manager -n opendatahub
-sleep 45
+oc set image deployment/odh-dashboard model-registry-ui=quay.io/opendatahub/odh-mod-arch-modular-architecture:v2.38.1-odh -n opendatahub
+
+sleep 120
+
 oc get pods -n opendatahub
 oc get pods -n odh-model-registries
 oc get routes -n odh-model-registries

--- a/opendatahub-subscription.yaml
+++ b/opendatahub-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: opendatahub-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: opendatahub-operator.v2.34.0
+  startingCSV: opendatahub-operator.v2.35.0

--- a/subscriptions-gpu.sh
+++ b/subscriptions-gpu.sh
@@ -15,8 +15,6 @@ while true; do
 done
 oc wait --for=jsonpath='{.status.phase}'=Succeeded "$NFD" -n openshift-nfd --timeout=600s
 
-./nfd-setup.sh
-
 oc apply -f ./kmm-ns.yaml
 oc create -f ./kmm-operatorgroup.yaml
 oc apply -f ./kmm-subscription.yaml


### PR DESCRIPTION
@johnmcollier @thepetk @jrichter1 FYI

this approximates what I sorted out with the  RHOAI team and executed manually to get their dashboard ready where I could promote from model catalog to model registry plus pull the model artifacts metadata and use it to fetch the model cards and push those as techdocs

next time I provision a cluster I'll try to run the odh kustomize job via `oc apply -k ./kustomize` and confirm things are still OK